### PR TITLE
43 Add class functionality code is duplicated across multiple functions

### DIFF
--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -277,6 +277,7 @@ contract Seed {
             "Seed: fee cannot be more than 45%"
         );
 
+        // The maximum required amount of the seed tokens to satisfy
         uint256 seedRequired = (_classCap * PRECISION) / _price;
 
         classes[_class].classCap = _classCap;
@@ -339,9 +340,7 @@ contract Seed {
             "Seed: fee cannot be more than 45%"
         );
 
-        // The maximum required amount of the seed tokens to satisfy
         // the maximum possible classCap is calculated.
-        uint256 seedRequired = (_classCap * PRECISION) / _price;
         classes.push( ContributorClass(
             _classCap,
             _individualCap,
@@ -349,9 +348,7 @@ contract Seed {
             _vestingDuration,
             _classVestingStartTime,
             _classFee,
-            0,
-            seedRequired,
-            (seedRequired * _classFee) / PRECISION ));
+            0));
     }
 
 
@@ -572,8 +569,8 @@ contract Seed {
                 "Seed: should transfer seed tokens to refund receiver"
             );
         } else {
-            uint256 seedAmountRequired = (hardCap * PRECISION) / price;
-            uint256 feeAmountRequired = (seedAmountRequired * fee) / PRECISION;
+            uint256 seedAmountRequired = (hardCap * PRECISION) / classes[0].price;
+            uint256 feeAmountRequired = (seedAmountRequired * classes[0].classFee) / PRECISION;
             // seed tokens to transfer = balance of seed tokens - totalSeedDistributed
             uint256 totalSeedDistributed = (seedAmountRequired +
                 feeAmountRequired) - (seedRemainder + feeRemainder);

--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -220,28 +220,13 @@ contract Seed {
         uint256 _classVestingStartTime,
         uint256 _classFee
     ) onlyAdmin public {
-        require(
-            endTime < _classVestingStartTime,
-            "Seed: vesting start time can't be less than endTime"
-        );
-        require(
-            _classFee < MAX_FEE,
-            "Seed: fee cannot be more than 45%"
-        );
-
-        // The maximum required amount of the seed tokens to satisfy
-        // the maximum possible classCap is calculated.
-        uint256 seedRequired = (_classCap * PRECISION) / _price;
-        classes.push( ContributorClass(
-                    _classCap,
-                    _individualCap,
-                    _price,
-                    _vestingDuration,
-                    _classVestingStartTime,
-                    _classFee,
-                    0,
-                    seedRequired,
-                    (seedRequired * _classFee) / PRECISION ));
+        checkAndPush(
+            _classCap,
+            _individualCap,
+            _price,
+            _vestingDuration,
+            _classVestingStartTime,
+            _classFee);
     }
 
     /**
@@ -334,30 +319,48 @@ contract Seed {
                 _classCaps.length == _classFee.length,
             "Seed: All provided arrays should be same size");
         for(uint8 i = 0; i < _classCaps.length; i++){
-            require(
-                endTime < _classVestingStartTime[i],
-                "Seed: vesting start time can't be less than endTime"
-            );
-            require(
-                _classFee[i] < MAX_FEE,
-                "Seed: fee cannot be more than 45%"
-            );
-
-            // The maximum required amount of the seed tokens to satisfy
-            // the maximum possible classCap is calculated.
-            uint256 seedRequired = (_classCaps[i] * PRECISION) / _prices[i];
-            classes.push(ContributorClass(
+            checkAndPush(
                 _classCaps[i],
                 _individualCaps[i],
                 _prices[i],
                 _vestingDurations[i],
                 _classVestingStartTime[i],
-                _classFee[i],
-                0,
-                seedRequired,
-                (seedRequired * _classFee[i]) / PRECISION));
+                _classFee[i]);
         }
     }
+
+    function checkAndPush(
+        uint256 _classCap,
+        uint256 _individualCap,
+        uint256 _price,
+        uint256 _vestingDuration,
+        uint256 _classVestingStartTime,
+        uint256 _classFee
+    ) onlyAdmin internal {
+        require(
+            endTime < _classVestingStartTime,
+            "Seed: vesting start time can't be less than endTime"
+        );
+        require(
+            _classFee < MAX_FEE,
+            "Seed: fee cannot be more than 45%"
+        );
+
+        // The maximum required amount of the seed tokens to satisfy
+        // the maximum possible classCap is calculated.
+        uint256 seedRequired = (_classCap * PRECISION) / _price;
+        classes.push( ContributorClass(
+            _classCap,
+            _individualCap,
+            _price,
+            _vestingDuration,
+            _classVestingStartTime,
+            _classFee,
+            0,
+            seedRequired,
+            (seedRequired * _classFee) / PRECISION ));
+    }
+
 
     /**
      * @dev                     Buy seed tokens.


### PR DESCRIPTION
functuon initialize() is not onlyAdmin - so we can't replace it with onlyAdmin checkAndPush and we  shoudn't remove onlyAdmin from checkAndPush() settings

closes <https://github.com/PrimeDAO/launch-contracts/issues/43>