### PR TITLE
33 There is no guarantee that users can buy hardCap amount of tokens

### DIFF
--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -389,6 +389,8 @@ contract Seed {
 
         if (!isFunded) {
             require(
+                // seedAmountRequired is an amount which is needed to be selled
+                // So when it's reached, for others will their balance be bigger or not - doesn't matter anymore.
                 seedToken.balanceOf(address(this)) >=
                     userClass.seedAmountRequired + userClass.feeAmountRequired,
                 "Seed: sufficient seeds not provided"

--- a/contracts/seed/Seed.sol
+++ b/contracts/seed/Seed.sol
@@ -389,7 +389,7 @@ contract Seed {
 
         if (!isFunded) {
             require(
-                // seedAmountRequired is an amount which is needed to be selled
+                // seedAmountRequired is an amount which is needed to be sold
                 // So when it's reached, for others will their balance be bigger or not - doesn't matter anymore.
                 seedToken.balanceOf(address(this)) >=
                     userClass.seedAmountRequired + userClass.feeAmountRequired,


### PR DESCRIPTION
closes <https://github.com/PrimeDAO/launch-contracts/issues/33>

"seedRemainder -= seedAmount; 
       feeRemainder -= feeAmount;

As the initial value of  seedRemainder is calculated on the basis of the initial price rather than the actual price at which tokens are being sold, this limit can be reached at any time during the sale - also before the hard cap, or even soft cap, is reached."

connected to https://github.com/PrimeDAO/launch-contracts/pull/28
as "fix bug with feeRemainder" have fixes so feeRemainder can not go < 0