### PR TITLE
Review/sc 690 add js types update class

### DIFF
--- a/test/helpers/contracts/ContractDeployer.js
+++ b/test/helpers/contracts/ContractDeployer.js
@@ -13,7 +13,8 @@ class ContractDeployer {
   }
 
   static async _deploy(type, from, args) {
-    let instance, builder;
+    let instance;
+    let builder;
     switch (type) {
       case types.SEED_DEPLOY_INSTANCE:
         {

--- a/test/helpers/contracts/contracts.js
+++ b/test/helpers/contracts/contracts.js
@@ -1,6 +1,12 @@
 const { ethers } = require("hardhat");
 const { getRootSigner } = require("../accounts/signers");
 
+/**
+ *
+ * @param {string} contract - "SeedFactory" | "Seed"
+ * @param {{from: string, args: any}} obj
+ * @returns
+ */
 async function deployContract(contract, { from, args }) {
   if (!args) args = [];
   if (!from) from = await getRootSigner();

--- a/test/helpers/contracts/seed/SeedFactory.js
+++ b/test/helpers/contracts/seed/SeedFactory.js
@@ -3,6 +3,8 @@ const { getRootSigner } = require("../../accounts/signers");
 const { types } = require("../../constants/constants");
 const { getERC20TokenInstances } = require("../tokens/tokens");
 
+/** @typedef {import("../../types/types.js").TestParams} TestParams */
+
 class SeedFactory {
   owner;
   instance;
@@ -28,6 +30,9 @@ class SeedFactory {
     this.owner = owner;
   }
 
+  /**
+   * @param {TestParams} params
+   */
   async setMasterCopy(params) {
     if (!params) params = {};
     if (!params.from) params.from = await getRootSigner();
@@ -36,6 +41,9 @@ class SeedFactory {
     return this;
   }
 
+  /**
+   * @param {TestParams} params
+   */
   async transferOwnership(params) {
     if (!params.from) params.from = await getRootSigner();
 
@@ -44,6 +52,9 @@ class SeedFactory {
     return this;
   }
 
+  /**
+   * @param {TestParams} params
+   */
   async deploySeed(params) {
     if (!params) params = {};
     if (!params.from) params.from = await getRootSigner();

--- a/test/helpers/contracts/seed/builders/SeedBuilder.js
+++ b/test/helpers/contracts/seed/builders/SeedBuilder.js
@@ -2,12 +2,19 @@
 const contractDeployer = require("../../ContractDeployer");
 const { types } = require("../../../constants/constants");
 
+/**
+ * @typedef {import("../../../types/types.js").Seed} Seed
+ */
 
 class SeedBuilder {
   constructor(instance) {
     this.instance = instance;
   }
 
+  /**
+   * @param {*=} params
+   * @returns {Promise<Seed>}
+   */
   static async create(params) {
     return contractDeployer.ContractDeployer.deploy(
       types.SEED_DEPLOY_INSTANCE,

--- a/test/helpers/contracts/seed/builders/SeedFactoryBuilder.js
+++ b/test/helpers/contracts/seed/builders/SeedFactoryBuilder.js
@@ -1,7 +1,15 @@
 const { types } = require("../../../constants/constants");
 const contractDeployer = require("../../ContractDeployer");
 
+/**
+ * @typedef {import("../../../types/types.js").SeedFactory} SeedFactory
+ */
+
 class SeedFactoryBuilder {
+  /**
+   * @param {*=} params
+   * @returns {Promie<SeedFactory>}
+   */
   static async create(params) {
     return contractDeployer.ContractDeployer.deploy(
       types.SEEDFACTORY_DEPLOY_INSTANCE,

--- a/test/helpers/contracts/tokens/tokens.js
+++ b/test/helpers/contracts/tokens/tokens.js
@@ -1,5 +1,11 @@
 const { getRootSigner } = require("../../accounts/signers");
 
+/**
+ *
+ * @param {*} params
+ * @param {*=} from
+ * @returns {any[]}
+ */
 const getERC20TokenInstances = async (params, from) => {
   /**
    * Function returns list with deployed token.

--- a/test/helpers/params/constructParams.js
+++ b/test/helpers/params/constructParams.js
@@ -19,6 +19,8 @@ const {
   fundingTokenParams,
 } = require("../constants/constants");
 
+/** @typedef {import("../types/types.js").TestParams} TestParams */
+
 async function getDefaultSeedParams(params) {
   const { root, beneficiary, admin } = await getNamedTestSigners();
   const seedTokenInstance = params.tokenInstances[0];
@@ -49,6 +51,7 @@ async function getDefaultSeedParams(params) {
   const tipPercentage = parseEther("0.02").toString();
   const tipVestingCliff = TEN_DAYS.toNumber();
   const tipVestingDuration = HUNDRED_DAYS.toNumber();
+  /** @type * */
   const tipping = [tipPercentage, tipVestingCliff, tipVestingDuration];
 
   return {
@@ -66,6 +69,9 @@ async function getDefaultSeedParams(params) {
   };
 }
 
+/**
+ * @param {TestParams} params
+ */
 async function getSeedInitParams(params) {
   const defaultParams = await getDefaultSeedParams(params);
 

--- a/test/helpers/types/types.js
+++ b/test/helpers/types/types.js
@@ -1,0 +1,34 @@
+/**
+ * @typedef {Object} TestParams
+ * @property {string=} admin -
+ * @property {string=} beneficiary -
+ * @property {string=} from -
+ * @property {string=} newOwner -
+ *
+ * @property {string=} seedAddress -
+ *
+ * @property {*=} tipping - [tipPercentage, tipVestingCliff]
+ * @property {*=} startAndEndTime - [startTime, endTime]
+ * @property {*=} defaultClassParameters -
+ * @property {*=} tokenAddresses - [seedTokenAddress, seedTokenAddress]
+ * @property {*=} softAndHardCaps - [softCap, hardCap]
+ * @property {*=} price -
+ * @property {boolean=} permissionedSeed -
+ * @property {*=} allowlist - []
+ *
+ * @property {*=} tokenInstances -
+ */
+
+//  import * as Types from "./types.js"
+
+//  /** @type {Types.MyType} */
+
+/**
+ * @typedef {import('../contracts/seed/SeedFactory.js').SeedFactory} SeedFactory
+ */
+/**
+ * @typedef {import('../contracts/seed/Seed.js').Seed} Seed
+ */
+
+
+module.exports = {}

--- a/test/seedFactory.js
+++ b/test/seedFactory.js
@@ -6,6 +6,10 @@ const {
   constants: { AddressZero },
 } = ethers;
 
+/** @typedef {import('./helpers/types/types').TestParams} TestParams */
+/** @typedef {import('./helpers/types/types').SeedFactory} SeedFactory */
+/** @typedef {import('./helpers/types/types').Seed} Seed */
+
 const { getNamedTestSigners } = require("./helpers/accounts/signers.js");
 const {
   SeedFactoryBuilder,
@@ -27,12 +31,15 @@ const {
 const { SEVEN_DAYS } = require("./helpers/constants/time.js");
 
 describe.only("> Contract: SeedFactory", () => {
-  let SeedFactoryInstance,
-    root,
-    beneficiary,
-    SeedInstance,
-    defaultSeedParameters,
-    tokenInstances;
+  /** @type {SeedFactory} */
+  let SeedFactoryInstance;
+  let root;
+  let admin;
+  let beneficiary;
+  /** @type {Seed} */
+  let SeedInstance;
+  let defaultSeedParameters;
+  let tokenInstances;
 
   before(async () => {
     ({ root, admin, beneficiary } = await getNamedTestSigners());


### PR DESCRIPTION
This PR introduces jsdoc types
- https://jsdoc.app/tags-param.html
- https://jsdoc.app/tags-typedef.html

## Why?
Untyped, it was hard to review all the functions and their params

## Goodies
- also allows go to definition now